### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE-MPL
+++ b/LICENSE-MPL
@@ -437,7 +437,7 @@ EXHIBIT A -Mozilla Public License.
      ``The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
      compliance with the License. You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/
+     https://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on an "AS IS"
      basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ support is limited to XHR-polling.
 ## How to build it
 
 Follow the usual kerfuffle given on
-<http://www.rabbitmq.com/plugin-development.html>; summary:
+<https://www.rabbitmq.com/plugin-development.html>; summary:
 
-    $ hg clone http://hg.rabbitmq.com/rabbitmq-public-umbrella
+    $ hg clone https://hg.rabbitmq.com/rabbitmq-public-umbrella
     $ cd rabbitmq-public-umbrella
     $ make co
     $ make
-    $ hg clone http://hg.rabbitmq.com/rabbit-socks
+    $ hg clone https://hg.rabbitmq.com/rabbit-socks
     $ cd rabbit-socks
     $ make
     $ cd ../rabbitmq-server
@@ -57,14 +57,14 @@ mochiweb.
 
 If `'rabbit_mochiweb'` is supplied as the interface, the listener will
 be registered with [RabbitMQ's Mochiweb
-plugin](http://www.rabbitmq.com//mochiweb.html) in the context
+plugin](https://www.rabbitmq.com//mochiweb.html) in the context
 `'socks'`.
 
 As usual, you can supply such a configuration on the command line:
 
     $ erl -rabbit_socks listeners [{rabbit_mochiweb, rabbit_socks_echo, []}]
 
-or in a [config file](http://www.erlang.org/doc/man/config.html).
+or in a [config file](https://www.erlang.org/doc/man/config.html).
 
 ### From code
 
@@ -106,4 +106,4 @@ A callback module must define these procedures:
 Returning `{error, Reason}` at any point will shut the connection
 down.
 
-[ws]: http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76 "WebSockets draft v76"
+[ws]: https://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76 "WebSockets draft v76"

--- a/priv/www/index.html
+++ b/priv/www/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>Rabbit Socks</title>
     <!-- script type="text/javascript"
-            src="http://cdn.socket.io/stable/socket.io.js"></script -->
+            src="https://cdn.socket.io/stable/socket.io.js"></script -->
     <style type="text/css">
       #output {
         border: 1px solid black;

--- a/priv/www/socketio.html
+++ b/priv/www/socketio.html
@@ -2,7 +2,7 @@
   <head>
     <title>Rabbit Socks</title>
     <script type="text/javascript"
-            src="http://cdn.socket.io/stable/socket.io.js"></script>
+            src="https://cdn.socket.io/stable/socket.io.js"></script>
     <style type="text/css">
       #output {
         border: 1px solid black;


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://hg.rabbitmq.com/rabbit-socks (UnknownHostException) with 1 occurrences migrated to:  
  https://hg.rabbitmq.com/rabbit-socks ([https](https://hg.rabbitmq.com/rabbit-socks) result UnknownHostException).
* http://hg.rabbitmq.com/rabbitmq-public-umbrella (UnknownHostException) with 1 occurrences migrated to:  
  https://hg.rabbitmq.com/rabbitmq-public-umbrella ([https](https://hg.rabbitmq.com/rabbitmq-public-umbrella) result UnknownHostException).
* http://cdn.socket.io/stable/socket.io.js (404) with 2 occurrences migrated to:  
  https://cdn.socket.io/stable/socket.io.js ([https](https://cdn.socket.io/stable/socket.io.js) result 404).
* http://www.rabbitmq.com//mochiweb.html (404) with 1 occurrences migrated to:  
  https://www.rabbitmq.com//mochiweb.html ([https](https://www.rabbitmq.com//mochiweb.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76 ([https](https://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76) result 200).
* http://www.rabbitmq.com/plugin-development.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/plugin-development.html ([https](https://www.rabbitmq.com/plugin-development.html) result 200).
* http://www.erlang.org/doc/man/config.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/config.html ([https](https://www.erlang.org/doc/man/config.html) result 301).
* http://www.mozilla.org/MPL/ with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).